### PR TITLE
Added base route to vite.config.js

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,7 @@ import vue from '@vitejs/plugin-vue'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue()],
+  base: '/dummy-api/',
   resolve: {
     alias: [
       {


### PR DESCRIPTION
base should be repo name. Help to deploy in github pages.
If there is no base path. It won't load any assets